### PR TITLE
Don't try to chmod nonexistent files if no option is set

### DIFF
--- a/custom-script/custom_vacuum.sh
+++ b/custom-script/custom_vacuum.sh
@@ -162,7 +162,10 @@ fi
 EOF
     fi
 
-    chmod +x "${IMG_DIR}/root/run_once.sh" "${IMG_DIR}/root/run.d/"*
+    if [ -d "${IMG_DIR}/root/run.d/" ]; then
+        chmod +x "${IMG_DIR}/root/run.d/"*
+    fi
+    chmod +x "${IMG_DIR}/root/run_once.sh"
     sed -i -E 's/^exit 0/\/root\/run_once.sh\nexit 0/' "${IMG_DIR}/etc/rc.local"
 
     if [ -f "${IMG_DIR}/etc/inittab" ]; then


### PR DESCRIPTION
If no password, region conversion or custom user option is set the `/root/run.d` directory never gets created and thus applying `chmod +x` to everything in it fails.