### PR TITLE
Avoid hardcoding binary paths

### DIFF
--- a/builder_vacuum.sh
+++ b/builder_vacuum.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Original Author: Dennis Giese [dgiese@dontvacuum.me]
 # Copyright 2017 by Dennis Giese
 #

--- a/custom-script/custom_adbd.sh
+++ b/custom-script/custom_adbd.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Replace xiaomis custom adbd with generic adbd version
 
 LIST_CUSTOM_PRINT_USAGE+=("custom_print_usage_adbd")

--- a/custom-script/custom_add_ssh_keys.sh
+++ b/custom-script/custom_add_ssh_keys.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Adding keys for ssh authentication
 
 LIST_CUSTOM_PRINT_USAGE+=("custom_print_usage_ssh_keys")

--- a/custom-script/custom_appproxy_patcher.sh
+++ b/custom-script/custom_appproxy_patcher.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # AppProxy patch to disable timezone checking (Anonymous author)
 
 LIST_CUSTOM_PRINT_USAGE+=("custom_print_usage_appproxy_patcher")

--- a/custom-script/custom_bin_addon.sh
+++ b/custom-script/custom_bin_addon.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Addon contains programs wget, bbe, nano, snmpd, htop
 
 LIST_CUSTOM_PRINT_USAGE+=("custom_print_usage_bin_addon")

--- a/custom-script/custom_bin_addon_sox.sh
+++ b/custom-script/custom_bin_addon_sox.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Addon contains program sox (SoX console audio player)
 
 LIST_CUSTOM_PRINT_USAGE+=("custom_print_usage_bin_addon_sox")

--- a/custom-script/custom_binding.sh
+++ b/custom-script/custom_binding.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Adding keybinding for bash
 
 LIST_CUSTOM_PRINT_USAGE+=("custom_print_usage_binding")

--- a/custom-script/custom_dns.sh
+++ b/custom-script/custom_dns.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Set custom dns servers
 
 LIST_CUSTOM_PRINT_USAGE+=("custom_print_usage_dns")

--- a/custom-script/custom_dns_catcher.sh
+++ b/custom-script/custom_dns_catcher.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Redirect and spoof outgoing dns requests(for xiaomi servers)
 # dnsmasq and drill for tests
 

--- a/custom-script/custom_dummycloud.sh
+++ b/custom-script/custom_dummycloud.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Install dummycloud
 
 LIST_CUSTOM_PRINT_USAGE+=("custom_print_usage_dummycloud")

--- a/custom-script/custom_example1.sh
+++ b/custom-script/custom_example1.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Example 1
 
 LIST_CUSTOM_PRINT_USAGE+=("custom_print_usage_example1")

--- a/custom-script/custom_example2.sh
+++ b/custom-script/custom_example2.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Example 2
 
 LIST_CUSTOM_PRINT_USAGE+=("custom_print_usage_example2")

--- a/custom-script/custom_greeting.sh
+++ b/custom-script/custom_greeting.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Add greeting to ssh
 
 LIST_CUSTOM_PRINT_USAGE+=("custom_print_usage_greeting")

--- a/custom-script/custom_history.sh
+++ b/custom-script/custom_history.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Add buildnumber and firmware version to history file
 
 LIST_CUSTOM_PRINT_USAGE+=("custom_print_usage_history")

--- a/custom-script/custom_multisound.sh
+++ b/custom-script/custom_multisound.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Make robot use different sounds at the same event
 
 LIST_CUSTOM_PRINT_USAGE+=("custom_print_usage_multisound")

--- a/custom-script/custom_ntp.sh
+++ b/custom-script/custom_ntp.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Set custom NTP servers
 
 LIST_CUSTOM_PRINT_USAGE+=("custom_print_usage_ntp")

--- a/custom-script/custom_off_cn_ny.sh
+++ b/custom-script/custom_off_cn_ny.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Turn off Chinese New Year
 
 LIST_CUSTOM_PRINT_USAGE+=("custom_print_usage_off_cn_ny")

--- a/custom-script/custom_off_logs.sh
+++ b/custom-script/custom_off_logs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Disables most log files creations and log uploads on the vacuum
 
 LIST_CUSTOM_PRINT_USAGE+=("custom_print_usage_off_logs")

--- a/custom-script/custom_off_updates.sh
+++ b/custom-script/custom_off_updates.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Disable xiaomi servers using hosts file for firmware updates
 
 LIST_CUSTOM_PRINT_USAGE+=("custom_print_usage_off_updates")

--- a/custom-script/custom_ramdisk.sh
+++ b/custom-script/custom_ramdisk.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Put rrlog directory to RAM-disk
 # From https://github.com/rand256/vacuum
 

--- a/custom-script/custom_random_phrases.sh
+++ b/custom-script/custom_random_phrases.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Xiaomi Vacuum v1/2 begins to talk random phrases when cleaning
 # Author: .//Hack (Alexander Krylov)
 # Site: https://4pda.ru/forum/index.php?showtopic=881982&st=8100#entry92139228

--- a/custom-script/custom_replace_miio.sh
+++ b/custom-script/custom_replace_miio.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Replaces miio to version 3.3.9
 
 LIST_CUSTOM_PRINT_USAGE+=("custom_print_usage_replace_miio")

--- a/custom-script/custom_rrlogd_patcher.sh
+++ b/custom-script/custom_rrlogd_patcher.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Patch rrlogd to disable log encryption (based on https://github.com/JohnRev/rrlogd-patcher)
 
 LIST_CUSTOM_PRINT_USAGE+=("custom_print_usage_rrlogd_patcher")

--- a/custom-script/custom_sound.sh
+++ b/custom-script/custom_sound.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Install custom sound files
 
 LIST_CUSTOM_PRINT_USAGE+=("custom_print_usage_sound")

--- a/custom-script/custom_timezone.sh
+++ b/custom-script/custom_timezone.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Timezone to be used in vacuum
 
 LIST_CUSTOM_PRINT_USAGE+=("custom_print_usage_timezone")

--- a/custom-script/custom_unprovisioned.sh
+++ b/custom-script/custom_unprovisioned.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Access your network in unprovisioned mode (currently only wpa2psk is supported)
 
 LIST_CUSTOM_PRINT_USAGE+=("custom_print_usage_unprovisioned")

--- a/custom-script/custom_valetudo.sh
+++ b/custom-script/custom_valetudo.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Install Valetudo (https://github.com/Hypfer/Valetudo)
 
 LIST_CUSTOM_PRINT_USAGE+=("custom_print_usage_valetudo")

--- a/custom-script/custom_valetudo_re.sh
+++ b/custom-script/custom_valetudo_re.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Install Valetudo RE (https://github.com/rand256/valetudo)
 
 LIST_CUSTOM_PRINT_USAGE+=("custom_print_usage_valetudo_re")

--- a/custom-script/custom_valetudo_wo_dummycloud.sh
+++ b/custom-script/custom_valetudo_wo_dummycloud.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Installing valetudo without dummycloud (deprecated)
 
 LIST_CUSTOM_PRINT_USAGE+=("custom_print_usage_valetudo_wo_dummycloud")

--- a/custom-script/files/phrases.sh
+++ b/custom-script/files/phrases.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 LANG=C LC_ALL=C
 DIR='/mnt/data/random_phrases/phrases'

--- a/custom-script/files/ramdisk-cleaner.sh
+++ b/custom-script/files/ramdisk-cleaner.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 if [ -d /mnt/data/rockrobo/rrlog ]; then
   items=/mnt/data/rockrobo/rrlog/*
   for item in $items

--- a/custom-script/files/unprovisioned/start_wifi.sh
+++ b/custom-script/files/unprovisioned/start_wifi.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 config="/opt/unprovisioned/wpa_supplicant.conf"
 log="/opt/unprovisioned/wpa_supplicant.log"


### PR DESCRIPTION
`bash` is not guaranteed to be available at `/bin/bash` or it may be outdated, e.g. on MacOS, the `/bin/bash` binary is extremely outdated and often users have another `bash` installed via package manager, which is then located at a different path, on NixOS `/bin/bash` does not exist at all:
```
$ ls -alh /bin       
total 4.0K
drwxr-xr-x 1 root root   4 Apr  9 11:57 .
drwxr-xr-x 1 root root 112 Feb  9 20:40 ..
lrwxrwxrwx 1 root root  75 Apr  9 11:57 sh -> /nix/store/lb3hli8d9536g45mndwfwyi6fpny0blh-bash-interactive-4.4-p23/bin/sh
```

Using `/usr/bin/env bash` is way more portable and provides expected results more often than `/bin/bash`, hence fix that.