### PR TITLE
OpenWRT specific installation changes

### DIFF
--- a/custom-script/custom_valetudo.sh
+++ b/custom-script/custom_valetudo.sh
@@ -64,7 +64,7 @@ function custom_function_valetudo() {
             install -D -m 0755  "${FILES_PATH}/valetudo-daemon.sh" "${IMG_DIR}/usr/local/bin/valetudo-daemon.sh"
         fi
 
-        install -m 0755 "${VALETUDO_PATH}/valetudo" "${IMG_DIR}/usr/local/bin/valetudo"
+        install -D -m 0755 "${VALETUDO_PATH}/valetudo" "${IMG_DIR}/usr/local/bin/valetudo"
         install -m 0644 "${VALETUDO_PATH}/deployment/valetudo.conf" "${IMG_DIR}/etc/init/valetudo.conf"
 
         if [ $ENABLE_DNS_CATCHER -ne 1 ]; then

--- a/custom-script/custom_valetudo_re.sh
+++ b/custom-script/custom_valetudo_re.sh
@@ -85,7 +85,7 @@ function custom_function_valetudo_re() {
             install -D -m 0755  "${FILES_PATH}/valetudo-daemon.sh" "${IMG_DIR}/usr/local/bin/valetudo-daemon.sh"
         fi
 
-        install -m 0755 "${VALETUDO_RE_PATH}/valetudo" "${IMG_DIR}/usr/local/bin/valetudo"
+        install -D -m 0755 "${VALETUDO_RE_PATH}/valetudo" "${IMG_DIR}/usr/local/bin/valetudo"
         install -m 0644 "${VALETUDO_RE_PATH}/valetudo.conf" "${IMG_DIR}/etc/init/valetudo.conf"
 
         if [ $ENABLE_DNS_CATCHER -ne 1 ]; then


### PR DESCRIPTION
the OpenWRT based firmwares do not have the folder /usr/local/ ,therefore the install command would fail on that. By adding -D the creation is forced.