### PR TITLE
Bugfix for setting volume in random phrases

### DIFF
--- a/custom-script/custom_vacuum.sh
+++ b/custom-script/custom_vacuum.sh
@@ -127,7 +127,7 @@ EOF
         VOLUME_OVERRIDE=''
         if [ -n "${RANDOM_PHRASES_VOLUME_OVERRIDE}" ]; then
             echo "++ Set 'random phrases' volume to ${RANDOM_PHRASES_VOLUME_OVERRIDE}"
-            VOLUME_OVERRIDE="${RANDOM_PHRASES_VOLUME_OVERRIDE};"
+            VOLUME_OVERRIDE="VOLUME_OVERRIDE=${RANDOM_PHRASES_VOLUME_OVERRIDE} "
         fi
         mkdir -p "${IMG_DIR}/root/run.d"
         cat << EOF > "${IMG_DIR}/root/run.d/init_phrases.sh"


### PR DESCRIPTION
After the daily run of the robot I noticed the volume of the random phrases was not doing anything.
I missed to set the override correctly, so this is the fix.