### PR TITLE
stderr should be logged in valetudo-daemon.sh

### DIFF
--- a/custom-script/files/valetudo-daemon.sh
+++ b/custom-script/files/valetudo-daemon.sh
@@ -11,8 +11,8 @@ while :; do
     fi
     echo '|/bin/false' > /proc/sys/kernel/core_pattern
     if [ -f "/root/bin/busybox" ]; then
-        /root/bin/busybox ionice -c3 nice -n 19 /usr/local/bin/valetudo >> /var/log/upstart/valetudo.log
+        /root/bin/busybox ionice -c3 nice -n 19 /usr/local/bin/valetudo >> /var/log/upstart/valetudo.log 2>&1
     else
-        nice -n 19 /usr/local/bin/valetudo >> /var/log/upstart/valetudo.log
+        nice -n 19 /usr/local/bin/valetudo >> /var/log/upstart/valetudo.log 2>&1
     fi
 done


### PR DESCRIPTION
Required debugging information can be easily lost if not doing that.