### PR TITLE
Actually wait for Valetudo to Shutdown

### DIFF
--- a/custom-script/files/S11valetudo
+++ b/custom-script/files/S11valetudo
@@ -9,7 +9,7 @@ load() {
 unload() {
     echo "stopping valetudo" >/dev/kmsg
     start-stop-daemon -K -q -p /var/run/valetudo-daemon.pid
-    killall valetudo
+    while killall valetudo; do sleep 1; done
 }
 
 status() {


### PR DESCRIPTION
This fixes issues with the machine having rebooted even before Valetudo did shutdown completely