### PR TITLE
fixing misspelled "password" options in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,11 +247,11 @@ Custom options for './custom-script/custom_dns_catcher.sh':
   --enable-dns-catcher       Redirect and spoof outgoing dns requests(for xiaomi servers)
 
 Custom options for './custom-script/custom_vacuum.sh':
-  --root-password=PASSWORD     Set password for root and custom user
-  --custom-user=USER           Add custom user
-  --custom-user-pass=PASSWORD  Set password for custom user
-  --convert2prc                Convert to Mainland China region
-  --convert2eu                 Convert to EU region
+  --root-password=PASSWORD         Set password for root and custom user
+  --custom-user=USER               Add custom user
+  --custom-user-password=PASSWORD  Set password for custom user
+  --convert2prc                    Convert to Mainland China region
+  --convert2eu                     Convert to EU region
 
 Custom options for './custom-script/custom_dropbear.sh':
   --custom-dropbear          Extract dropbear_v2019.78.tgz to firmware (Dropbear v2019.78 with Ed25519 support)

--- a/custom-script/custom_vacuum.sh
+++ b/custom-script/custom_vacuum.sh
@@ -16,7 +16,7 @@ function custom_print_usage_08_vacuum() {
     cat << EOF
 
 Custom parameters for '${BASH_SOURCE[0]}':
-[--root-password=PASSWORD|--custom-user=USER|--custom-user-pass=PASSWORD|
+[--root-password=PASSWORD|--custom-user=USER|--custom-user-password=PASSWORD|
 --convert2prc|--convert2eu]
 EOF
 }
@@ -25,11 +25,11 @@ function custom_print_help_08_vacuum() {
     cat << EOF
 
 Custom options for '${BASH_SOURCE[0]}':
-  --root-pass=PASSWORD         Set password for root and custom user
-  --custom-user=USER           Add custom user
-  --custom-user-pass=PASSWORD  Set password for custom user
-  --convert2prc                Convert to Mainland China region
-  --convert2eu                 Convert to EU region
+  --root-password=PASSWORD         Set password for root and custom user
+  --custom-user=USER               Add custom user
+  --custom-user-password=PASSWORD  Set password for custom user
+  --convert2prc                    Convert to Mainland China region
+  --convert2eu                     Convert to EU region
 EOF
 }
 


### PR DESCRIPTION
the `custom_vacuum.sh` script read the cmd-options `root-password` and `user-password`.
but in the `README.md` and shell script inline documentation booth parameters were named `root-pass` and `user-pass`.

this pull request fixes the misspelling in both docs.